### PR TITLE
实现日志的持久化存储，新增模块处理日志

### DIFF
--- a/data/log/.gitignore
+++ b/data/log/.gitignore
@@ -1,0 +1,1 @@
+content.db

--- a/src/cli/handler.py
+++ b/src/cli/handler.py
@@ -4,8 +4,7 @@ from tabulate import tabulate
 from utils.config import CONFIG
 from utils.error import ModuleLoadError
 
-from module.interface import ModuleName
-from module.interface.info import moduleStatusMap
+from module.interface.info import moduleStatusMap, ModuleName
 from module.interface.manager import MANAGER
 from message import Message, MessageKind
 from .kind import CommandHandleError, CommandUsageError

--- a/src/module/booter.py
+++ b/src/module/booter.py
@@ -1,8 +1,8 @@
 from message import Message, MessageKind
 
 from .core import BasicCore, HandleResult
-from .interface import ModuleName, BooterInterface
-from .interface.info import ModuleStatus
+from .interface import BooterInterface
+from .interface.info import ModuleStatus, ModuleName
 from .crawler.interface import CrawlerInterface
 from .renderer.interface import RendererInterface
 

--- a/src/module/bot/__init__.py
+++ b/src/module/bot/__init__.py
@@ -4,11 +4,9 @@ from ..interface import BasicModule
 class BasicBot(BasicModule):
     system_prompt = "你现在是一名主播，请回答观众问题，请将回答控制在10字以内。"
 
-    def __init__(self):
-        super().__init__()
-
     def load_config(self):
         pass
 
+    @BasicModule._handle_log
     def talk(self, query: str) -> str:
         return self._sub_module("caller").single_call(query, True)

--- a/src/module/bot/simple.py
+++ b/src/module/bot/simple.py
@@ -5,6 +5,7 @@ class SimpleBot(BasicBot):
     def load_config(self):
         pass
 
+    @BasicBot._handle_log
     def talk(self, query: str) -> str:
         caller = self._sub_module("caller")
         searcher = self._sub_module("searcher")

--- a/src/module/core/__init__.py
+++ b/src/module/core/__init__.py
@@ -42,12 +42,10 @@ class BasicCore(BasicModule):
 
             # 接收消息
             message = self.__msg_queue.pop()
-            print("receive:", message.content)
             self._log(MessageLog.from_message(message))
 
             # 生成回答
             response = self._sub_module("bot").talk(message.content)
-            print("answer:", response)
             self._log(
                 MessageLog(
                     MessageKind.Assistant,
@@ -59,7 +57,6 @@ class BasicCore(BasicModule):
 
             # 生成语音
             speech = self._sub_module("speaker").speak(response)
-            print("speech:", speech)
 
             # 响应处理结果, 只有对应回调函数非空时, 才进行处理
             if self.__handle_callback is not None:

--- a/src/module/interface/__init__.py
+++ b/src/module/interface/__init__.py
@@ -1,26 +1,14 @@
 from abc import abstractmethod, ABCMeta
 from typing import List, Dict, Callable, Self
 from threading import Thread
-from enum import Enum
 
 from utils.config import CONFIG
 from utils.time import now, sub_time
 from message import Message
 
-from .info import ModuleStatus
+from .info import ModuleStatus, ModuleName
 from .log.interface import ModuleLog, ModuleCallback
 from .log import HandleLog
-
-
-class ModuleName(Enum):
-    BOOTER = "booter"
-    CORE = "core"
-    BOT = "bot"
-    CALLER = "caller"
-    SEARCHER = "searcher"
-    SPEAKER = "speaker"
-    CRAWLER = "crawler"
-    RENDERER = "renderer"
 
 
 class BasicModule(metaclass=ABCMeta):

--- a/src/module/interface/__init__.py
+++ b/src/module/interface/__init__.py
@@ -173,8 +173,14 @@ class BasicModule(metaclass=ABCMeta):
     def update_status(self, status: ModuleStatus):
         self.__status = status
 
-    def update_sub_module(self, sub_module: Self):
-        self.__sub_modules[sub_module.name] = sub_module
+    def update_submodule(self, name: str, sub_module: Self):
+        """更新模块的子模块指针，由于子模块可能为空，因此需要传入名称
+
+        Args:
+            name (str): 模块名称
+            sub_module (Self): 子模块指针
+        """
+        self.__sub_modules[name] = sub_module
 
 
 class BooterInterface(BasicModule, metaclass=ABCMeta):

--- a/src/module/interface/info.py
+++ b/src/module/interface/info.py
@@ -1,5 +1,5 @@
 from typing import List, Self
-from enum import IntEnum, unique
+from enum import Enum, IntEnum, unique
 
 
 @unique
@@ -44,6 +44,17 @@ moduleStatusMap = {
     ModuleStatus.RunError: "运行异常",
     ModuleStatus.StopError: "停止异常",
 }
+
+
+class ModuleName(Enum):
+    BOOTER = "booter"
+    CORE = "core"
+    BOT = "bot"
+    CALLER = "caller"
+    SEARCHER = "searcher"
+    SPEAKER = "speaker"
+    CRAWLER = "crawler"
+    RENDERER = "renderer"
 
 
 class ModuleInfo:

--- a/src/module/interface/log/__init__.py
+++ b/src/module/interface/log/__init__.py
@@ -1,30 +1,41 @@
 from message import MessageKind, Message
+from module.interface.info import ModuleStatus, ModuleName
+
 from .interface import ModuleLog, ModuleLogKind
-from ..info import ModuleStatus
 
 
-class ModuleStatusLog(ModuleLog):
+class StatusLog(ModuleLog):
     def __init__(self, name: str, status: ModuleStatus):
         super().__init__(
-            ModuleLogKind.ModuleStatus,
+            ModuleLogKind.STATUS,
             {
-                "name": name,
                 "status": status,
             },
+            name=name,
         )
 
 
 class MessageLog(ModuleLog):
     def __init__(self, messageKind: MessageKind, content: str, to_admin: bool = False):
+        data = {
+            "content": content,
+            "kind": messageKind,
+        }
+
+        if to_admin:
+            data["toAdmin"] = True
+
         super().__init__(
-            ModuleLogKind.Message,
-            {
-                "content": content,
-                "kind": messageKind,
-                "toAdmin": to_admin,
-            },
+            ModuleLogKind.MESSAGE,
+            data,
+            name=ModuleName.CORE.value,
         )
 
     @staticmethod
     def from_message(message: Message, to_admin: bool = False):
         return MessageLog(message.kind, message.content, to_admin)
+
+
+class HandleLog(ModuleLog):
+    def __init__(self, name: str, kind: str, time: float):
+        super().__init__(ModuleLogKind.HANDLE, {"time": time}, name=name, kind=kind)

--- a/src/module/interface/log/database.py
+++ b/src/module/interface/log/database.py
@@ -1,0 +1,32 @@
+from utils.time import now_str
+from utils.database import Database
+from utils.file import dump_json
+
+from . import ModuleLog
+
+
+class LogDatabase(Database):
+    def __init__(self):
+        super().__init__("log", "content")
+
+    def _create(self):
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS log (
+                id INTEGER PRIMARY KEY autoincrement,
+                log_kind TINYINT    NOT NULL,
+                name TEXT,
+                kind TEXT,
+                time DATETIME   NOT NULL,
+                content TEXT    NOT NULL
+            )"""
+        )
+
+    def append(self, log: ModuleLog):
+        self._conn.execute(
+            "INSERT INTO log VALUES (?, ?, ?, ?, ?, ?)",
+            (None, log.log_kind, log.name, log.kind, now_str(), dump_json(log.content)),
+        )
+        self._conn.commit()
+
+
+DATABASE = LogDatabase()

--- a/src/module/interface/log/interface.py
+++ b/src/module/interface/log/interface.py
@@ -4,22 +4,41 @@ from enum import IntEnum
 
 import json
 
+from utils.time import now_str
+
 
 class ModuleLogKind(IntEnum):
     # 模块状态相关
-    ModuleStatus = 1
+    STATUS = 1
 
     # 消息发送相关
-    Message = 2
+    MESSAGE = 2
+
+    # 消息处理相关
+    HANDLE = 3
 
 
 class ModuleLog(metaclass=ABCMeta):
-    def __init__(self, kind: ModuleLogKind, content: Dict):
-        self.kind = kind
+    def __init__(
+        self,
+        log_kind: ModuleLogKind,
+        content: Dict,
+        name: str = None,
+        kind: str = None,
+    ):
+        self.log_kind = log_kind
         self.content = content
+        self.name = name
+        self.kind = kind
+        self.time = now_str()
 
     def to_json(self) -> str:
-        data = {"kind": self.kind, "content": self.content}
+        data = {"logKind": self.log_kind, "content": self.content, "time": self.time}
+
+        if self.name is not None:
+            data["name"] = self.name
+        if self.kind is not None:
+            data["kind"] = self.kind
 
         return json.dumps(data)
 

--- a/src/module/interface/manager.py
+++ b/src/module/interface/manager.py
@@ -435,7 +435,7 @@ class ModuleManager:
 
             # 更新父模块的子模块
             print(sup_cell.module.name)
-            sup_cell.module.update_sub_module(cell.module)
+            sup_cell.module.update_submodule(cell.name, cell.module)
 
         # FIXME: 使用抛出异常解决运行不成功的问题
         return True, None

--- a/src/module/interface/manager.py
+++ b/src/module/interface/manager.py
@@ -9,8 +9,9 @@ from message import Message
 from . import BasicModule, BooterInterface
 from .info import ModuleInfo, ModuleStatus
 
+from .log.database import DATABASE
 from .log.interface import ModuleLog, ModuleCallback
-from .log import ModuleStatusLog
+from .log import StatusLog
 
 CONFIG_PATH = "modules.json"
 
@@ -255,10 +256,12 @@ class ModuleManager:
             )
 
     def log(self, log: ModuleLog):
-        # TODO: 发送日志后的处理函数
+        # 存在其他线程使用回调函数调用此线程，可能会造成线程不安全
 
         if self.__log_callback is not None:
             self.__log_callback(log)
+
+        DATABASE.append(log)
 
     # ----- 模块控制 ----- #
 
@@ -487,7 +490,7 @@ class ModuleManager:
         cell.status = new_status
         if cell.module is not None:
             cell.module.update_status(new_status)
-        self.log(ModuleStatusLog(name, new_status))
+        self.log(StatusLog(name, new_status))
 
     def set_log_callback(self, callback: LogCallBack):
         self.__log_callback = callback

--- a/src/module/speaker/basic.py
+++ b/src/module/speaker/basic.py
@@ -63,6 +63,7 @@ class BasicSpeaker(SpeakerInterface):
         # 获取修改后的XML内容字符串
         return ssml.format(text=text)
 
+    @SpeakerInterface._handle_log
     def speak(self, text) -> str:
         if not os.path.exists(self.__output_dir):
             os.makedirs(self.__output_dir)

--- a/src/server/api/control.py
+++ b/src/server/api/control.py
@@ -32,16 +32,16 @@ def start(name: str, control: str):
 
     if control == "start":
         # Notice: 启动子模块时，也会递归启动父模块
-        flag, status = MANAGER.start(name, with_sup=True)
+        MANAGER.start(name, with_sup=True)
     elif control == "stop":
-        flag, status = MANAGER.stop(name)
+        MANAGER.stop(name)
 
     # 如果模块启动失败，则说明是当前状态不支持
-    if not flag:
-        return Result.create(
-            code=ErrorCode.ModuleStatusNotSupported,
-            data={"status": status, "statusLabel": moduleStatusMap[status]},
-        )
+    # if not flag:
+    #     return Result.create(
+    #         code=ErrorCode.ModuleStatusNotSupported,
+    #         data={"status": status, "statusLabel": moduleStatusMap[status]},
+    #     )
 
     return Result.create()
 

--- a/src/server/api/control.py
+++ b/src/server/api/control.py
@@ -1,8 +1,7 @@
 from typing import Dict
 from flask import Blueprint, request
 
-from module.interface import ModuleName
-from module.interface.info import moduleStatusMap
+from module.interface.info import ModuleName, moduleStatusMap
 from module.interface.manager import MANAGER
 from utils.config import CONFIG
 

--- a/src/utils/database/__init__.py
+++ b/src/utils/database/__init__.py
@@ -1,0 +1,16 @@
+import sqlite3
+from abc import ABCMeta, abstractmethod
+from utils.file import join_path
+
+BASE_PATH = "data"
+
+
+class Database(metaclass=ABCMeta):
+    def __init__(self, path: str, database: str, check_same_thread: bool = False):
+        name = join_path(BASE_PATH, path, database) + ".db"
+        self._conn = sqlite3.connect(name, check_same_thread=check_same_thread)
+
+        self._create()
+
+    @abstractmethod
+    def _create(self): ...

--- a/src/utils/file.py
+++ b/src/utils/file.py
@@ -1,6 +1,6 @@
 import json
 
-from typing import Dict, List
+from typing import Dict, List, Any
 
 
 def load_json(path: str) -> Dict | List:
@@ -25,3 +25,11 @@ def load_lines(path: str) -> List[str]:
             return messages
     except BaseException:
         return []
+
+
+def join_path(*args: str):
+    return "/".join(args)
+
+
+def dump_json(o: Any, indent: int = 0) -> str:
+    return json.dumps(o, ensure_ascii=False, indent=indent)

--- a/src/utils/time.py
+++ b/src/utils/time.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+
+def now_str() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def now() -> datetime:
+    return datetime.now()
+
+
+def sub_time(start: datetime, end: datetime) -> float:
+    delta = end - start
+
+    return delta.seconds + delta.microseconds / 1e6


### PR DESCRIPTION
# Feat

1. 使用`sqlite3` 持久化存储日志信息，因此请确保本地安装了 sqlite
2. 使用 AOP 思想计算模块处理函数(`talk`, `speak` 等)的处理时间。使用方法如下

    ```python
    @BasicBot._handle_log
    def talk(self, query: str) -> str:
        ...
    ```
    > 注意：该注解不会继承，因此每个子类函数都要使用该注解

# Fix

1. 在Webui 的API中，删除控制函数遗留的返回值
2. `update_submodule` 函数中，当原指针为空时，导致找不到模块名称
