### PR TITLE
实现 CLI 控制器中控制 Docker 容器

### DIFF
--- a/src/cli/handler.py
+++ b/src/cli/handler.py
@@ -3,6 +3,8 @@ from tabulate import tabulate
 
 from utils.error import ModuleLoadError
 
+from framework.docker.client import DOCKER_CLIENT
+
 from module.interface.info import moduleStatusMap, ModuleName
 from module.interface.manager import MANAGER
 from message import Message, MessageKind
@@ -92,6 +94,26 @@ def handle_send(args: List[str]):
 
     # 如果消息未能发送成功，则说明模块未启动
     MANAGER.send(message)
+
+
+def handle_docker(args: List[str]):
+    if len(args) < 4:
+        raise CommandUsageError(args[0])
+
+    [cmd, name, kind] = args[1:]
+
+    if cmd not in ["start", "stop"]:
+        raise CommandUsageError(args[0])
+
+    if not DOCKER_CLIENT.check_instance_has_docker(name, kind):
+        raise CommandHandleError(
+            f"the kind '{kind}' of name '{name}' doesn't have docker"
+        )
+
+    if cmd == "start":
+        DOCKER_CLIENT.start_module_container(name, kind)
+    elif cmd == "stop":
+        DOCKER_CLIENT.stop_module_container(name, kind)
 
 
 def handle_reload(_ignored): ...

--- a/src/cli/kind.py
+++ b/src/cli/kind.py
@@ -6,6 +6,7 @@ COMMANDS = {
     "change": {"usage": "name kind"},
     "send": {"usage": '"content"'},
     "reload": {"usage": ""},
+    "docker": {"usage": "[start|stop] name kind"},
 }
 
 

--- a/src/framework/docker/client.py
+++ b/src/framework/docker/client.py
@@ -163,6 +163,24 @@ class ModuleDockerClient(DockerClient):
 
         return self.get_container_status(_to_container_name(name, kind))
 
+    def check_instance_has_docker(self, name: str, kind: str) -> bool:
+        """校验实现实例是否存在 docker
+
+        Args:
+            name (str): 模块名称
+            kind (str): 模块实现类型
+
+        Returns:
+            bool: 结果
+        """
+
+        info_dict = self.__docker_info_list
+
+        if name not in info_dict or kind not in info_dict[name]:
+            return False
+
+        return info_dict[name][kind] is not None
+
     @property
     def docker_info_list(self) -> List[Dict[str, Any]]:
         """获取 Docker 信息列表


### PR DESCRIPTION
# 使用方法

```bash
> docker start searcher es
> docker stop seacher es
```

# 注意事项

1. 请确保 Docker Daemon 能够正常访问（访问端口默认为 `2375`）
2. Docker 容器启动后，不代表里面的服务真正能被使用